### PR TITLE
DEVOPS-452: pylint ignore: skip source files from upstream repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
         language: system
         require_serial: true  # pylint does its own parallelism
         types: [python]
-        files: ^(omf/fileio/geoh5|omf/scripts|tests)/
+        exclude: ^docs/
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/pylintrc
+++ b/pylintrc
@@ -46,7 +46,9 @@ ignore=CVS
 
 # Add files or directories matching the regex patterns to the ignore-list. The
 # regex matches against paths and can be in Posix or Windows format.
-ignore-paths=^omf/(?!(scripts|fileio)).*
+ignore-paths=^omf/fileio/fileio\.py$,  # skip source files from upstream repo
+             ^omf/fileio/utils\.py$,
+             ^omf/[^/]+$
 
 # Files or directories matching the regex patterns are skipped. The regex
 # matches against base names, not paths. The default value ignores Emacs file


### PR DESCRIPTION
**DEVOPS-452 - apply latest version of python template repos to all repos**
