### PR TITLE
DEVOPS-515: restore 3.3.0 alpha version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     -   id: pycln
         args: [--config=pyproject.toml]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.0
     hooks:
     -   id: ruff
         args:

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ omf
     :alt: pytest
 
 
-Version: 3.4.0-alpha.1
+Version: 3.3.0-alpha.1
 
 API library for Open Mining Format, a new standard for mining data backed by
 the `Global Mining Standards & Guidelines Group <https://gmggroup.org/>`_.

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mira-omf" %}
-{% set version = "3.4.0a1" %}
+{% set version = "3.3.0a1" %}
 
 package:
   name: {{ name|lower }}

--- a/omf/__init__.py
+++ b/omf/__init__.py
@@ -30,7 +30,7 @@ from .texture import ImageTexture
 from .volume import VolumeElement, VolumeGridGeometry
 
 
-__version__ = "3.4.0-alpha.1"
+__version__ = "3.3.0-alpha.1"
 __author__ = "Global Mining Standards and Guidelines Group"
 __license__ = "MIT License"
 __copyright__ = "Copyright 2017 Global Mining Standards and Guidelines Group"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mira-omf"
-version = "3.4.0-alpha.1"
+version = "3.3.0-alpha.1"
 description = "API Library for Open Mining Format"
 license = "MIT"
 authors = [


### PR DESCRIPTION
restore 3.3.0 version moved by mistake (from https://github.com/MiraGeoscience/omf/pull/74)